### PR TITLE
Add combining datasets with pandas notebook

### DIFF
--- a/25l-notes/Combining_Dataset_Pandas.ipynb
+++ b/25l-notes/Combining_Dataset_Pandas.ipynb
@@ -1,0 +1,2776 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7450a510",
+   "metadata": {},
+   "source": [
+    "## Pandas\n",
+    "### Introduction to pandas objects\n",
+    "A series is a 1D array of indexed data\n",
+    "- list = 10,20,30,40\n",
+    "- index = 0,1,2,3\n",
+    "- pdSeries([10,20,30,40])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9e3ced57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0ca5e519",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[10, 20, 30, 40, 50]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# creating a series\n",
+    "list = [10,20,30,40, 50]\n",
+    "list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7e6339d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    10\n",
+       "1    20\n",
+       "2    30\n",
+       "3    40\n",
+       "4    50\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.Series(list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b4e492",
+   "metadata": {},
+   "source": [
+    "## DataFrame\n",
+    "A collection of series that share the same index.\n",
+    "- It is 2D, it has columns and Rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "07b8a0f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Name': ['John', 'Reagan', 'Nathan', 'Abdullahi', 'Bethany'],\n",
+       " 'Score': [85, 90, 78, 88, 92],\n",
+       " 'Age': [20, 21, 19, 22, 20],\n",
+       " 'Location': ['Juja', 'Utawala', 'Uthiru', 'Kilimani', 'Membley']}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#creating a dataframe\n",
+    "data = {\n",
+    "    \"Name\": [\"John\", \"Reagan\", \"Nathan\", \"Abdullahi\", \"Bethany\"],\n",
+    "    \"Score\":[85,90,78,88,92],\n",
+    "    \"Age\": [20,21,19,22,20],\n",
+    "    \"Location\": [\"Juja\", \"Utawala\", \"Uthiru\", \"Kilimani\", \"Membley\"]\n",
+    "}  \n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5ca9c5ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame(data)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19487c4c",
+   "metadata": {},
+   "source": [
+    "### viewing and accessing data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7bba94e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Name  Score  Age Location\n",
+       "0    John     85   20     Juja\n",
+       "1  Reagan     90   21  Utawala"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "af4df8b9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.tail(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3df95f8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 5 entries, 0 to 4\n",
+      "Data columns (total 4 columns):\n",
+      " #   Column    Non-Null Count  Dtype \n",
+      "---  ------    --------------  ----- \n",
+      " 0   Name      5 non-null      object\n",
+      " 1   Score     5 non-null      int64 \n",
+      " 2   Age       5 non-null      int64 \n",
+      " 3   Location  5 non-null      object\n",
+      "dtypes: int64(2), object(2)\n",
+      "memory usage: 292.0+ bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# summary\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0979af4f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>86.600000</td>\n",
+       "      <td>20.400000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>5.458938</td>\n",
+       "      <td>1.140175</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>78.000000</td>\n",
+       "      <td>19.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>85.000000</td>\n",
+       "      <td>20.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>88.000000</td>\n",
+       "      <td>20.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>90.000000</td>\n",
+       "      <td>21.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>92.000000</td>\n",
+       "      <td>22.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Score        Age\n",
+       "count   5.000000   5.000000\n",
+       "mean   86.600000  20.400000\n",
+       "std     5.458938   1.140175\n",
+       "min    78.000000  19.000000\n",
+       "25%    85.000000  20.000000\n",
+       "50%    88.000000  20.000000\n",
+       "75%    90.000000  21.000000\n",
+       "max    92.000000  22.000000"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#statistics\n",
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "2da154b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0         John\n",
+       "1       Reagan\n",
+       "2       Nathan\n",
+       "3    Abdullahi\n",
+       "4      Bethany\n",
+       "Name: Name, dtype: object"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Accesing columns\n",
+    "df.Name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dd1d523",
+   "metadata": {},
+   "source": [
+    "# data Indexing and Selection\n",
+    "loc() - (label- based indexing)\n",
+    "- label names or rows\n",
+    "- can handle non integer labels such as strings\n",
+    "- when slicings it includes both the start and the end\n",
+    "\n",
+    "iloc() - (interger-location based indexing)\n",
+    "- uses interger position to select data\n",
+    "- ignores the actual labels of rows and columns\n",
+    "- when slicing, it includes the end position\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "fa8f6c6f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Name        John\n",
+       "Score         85\n",
+       "Age           20\n",
+       "Location    Juja\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "0a1b5581",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[0:4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "52b7ab06",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'John'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[0,\"Name\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "ff4d3be4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'John'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.iloc[0,0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "837257a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    85\n",
+       "1    90\n",
+       "2    78\n",
+       "Name: Score, dtype: int64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.loc[0:2, \"Score\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0860c0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# understand loc and iloc\n",
+    "# understand labels\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "b4d09ad4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Accessing score using labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "4ba2d877",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>John</th>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Reagan</th>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Nathan</th>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Abdullahi</th>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Bethany</th>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Score  Age  Location\n",
+       "John          85   20      Juja\n",
+       "Reagan        90   21   Utawala\n",
+       "Nathan        78   19    Uthiru\n",
+       "Abdullahi     88   22  Kilimani\n",
+       "Bethany       92   20   Membley"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#creating a dataframe\n",
+    "data = pd.DataFrame({\n",
+    "    \"Score\":[85,90,78,88,92],\n",
+    "    \"Age\": [20,21,19,22,20],\n",
+    "    \"Location\": [\"Juja\", \"Utawala\", \"Uthiru\", \"Kilimani\", \"Membley\"]\n",
+    "},\n",
+    "index = [\"John\", \"Reagan\", \"Nathan\", \"Abdullahi\", \"Bethany\"])\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "d5a365d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "85"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Accessing a single column\n",
+    "data.loc[\"John\", \"Score\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "13026eaf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.iloc[0,1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "b71dbd2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>John</th>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Nathan</th>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Score  Age\n",
+       "John       85   20\n",
+       "Nathan     78   19"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.loc[[\"John\", \"Nathan\"], [\"Score\", \"Age\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d38076e",
+   "metadata": {},
+   "source": [
+    "## **Assignment Combining Data**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d453b3c",
+   "metadata": {},
+   "source": [
+    "**1. Why Combine Data in NumPy?**\n",
+    "\n",
+    "In real-world data analysis, data may come in parts — different arrays representing:\n",
+    "- different features (columns),\n",
+    "- different observations (rows),\n",
+    "- or even from different files.\n",
+    "\n",
+    "NumPy provides several efficient tools to combine or stack these arrays into a single unified structure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6cc0067",
+   "metadata": {},
+   "source": [
+    "***2. Methods to Combine Arrays in NumPy***\n",
+    "\n",
+    "- np.concatenate()\n",
+    "- np.stack()\n",
+    "- np.hstack() and np.vstack()\n",
+    "- np.column_stack() and np.row_stack()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f7c4027",
+   "metadata": {},
+   "source": [
+    "### i. np.concatenate() – Basic Concatenation\n",
+    "This joins arrays along an existing axis (axis 0 = rows, axis 1 = columns)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "30a46eb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[5]\n",
+      " [6]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "b = np.array([[5, 6]])\n",
+    "print(b.T)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d69669b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 2)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0dec2155",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 2 5]\n",
+      " [3 4 6]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Concatenate by rows (default axis=0)\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "a = np.array([[1, 2], [3, 4]])\n",
+    "b = np.array([[5, 6]])\n",
+    "\n",
+    "result = np.concatenate((a, b.T), axis=1)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2573c7e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1, 2],\n",
+       "       [3, 4]])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "482f48ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2, 2)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "fea2f1b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 2)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1ecfa47",
+   "metadata": {},
+   "source": [
+    "Arrays must have the same number of columns for axis=0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "59ea87e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 2 5 6]\n",
+      " [3 4 7 8]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Concatenate by columns (axis=1)\n",
+    "\n",
+    "a = np.array([[1, 2], [3, 4]])\n",
+    "b = np.array([[5, 6], [7, 8]])\n",
+    "\n",
+    "result = np.concatenate((a, b), axis=1)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b80dc86",
+   "metadata": {},
+   "source": [
+    "Arrays must have the same number of rows for axis=1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5a28c0c",
+   "metadata": {},
+   "source": [
+    "### ii. np.stack() – Combine Along a New Axis\n",
+    "Unlike concatenate(), this adds a new dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2a00d274",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 2]\n",
+      " [3 4]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.array([1, 2])\n",
+    "b = np.array([3, 4])\n",
+    "\n",
+    "stacked = np.stack((a, b), axis=0)  # shape becomes (2, 2)\n",
+    "print(stacked)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a86c9e1",
+   "metadata": {},
+   "source": [
+    "### iii. np.hstack() – Horizontal Stack (Column-wise)\n",
+    "Joins arrays horizontally (columns side by side)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "1a6f697c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1 2 3 4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.array([1, 2])\n",
+    "b = np.array([3, 4])\n",
+    "\n",
+    "result = np.hstack((a, b))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "0a838563",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 3]\n",
+      " [2 4]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For 2D\n",
+    "a = np.array([[1], [2]])\n",
+    "b = np.array([[3], [4]])\n",
+    "\n",
+    "result = np.hstack((a, b))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e4d9110",
+   "metadata": {},
+   "source": [
+    "### iV. np.vstack() – Vertical Stack (Row-wise)\n",
+    "Joins arrays vertically (rows stacked on top of each other)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "7f62cc66",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 2]\n",
+      " [3 4]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.array([1, 2])\n",
+    "b = np.array([3, 4])\n",
+    "\n",
+    "result = np.vstack((a, b))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf2dca9c",
+   "metadata": {},
+   "source": [
+    "### v. np.column_stack() – Stack 1D Arrays as Columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "8279fee9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 4]\n",
+      " [2 5]\n",
+      " [3 6]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.array([1, 2, 3])\n",
+    "b = np.array([4, 5, 6])\n",
+    "\n",
+    "result = np.column_stack((a, b))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a4fc082",
+   "metadata": {},
+   "source": [
+    "Useful for reshaping multiple 1D arrays into 2D column vectors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6e80910",
+   "metadata": {},
+   "source": [
+    "### vi. np.row_stack() – Stack 1D Arrays as Rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "9ea8aec7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 2 3]\n",
+      " [4 5 6]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.array([1, 2, 3])\n",
+    "b = np.array([4, 5, 6])\n",
+    "\n",
+    "result = np.row_stack((a, b))\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b819ff23",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "| Method               | What It Does                                   | Good For                     |\n",
+    "|----------------------|-----------------------------------------------|------------------------------|\n",
+    "| `np.concatenate()`   | Joins arrays along an existing axis           | General merging              |\n",
+    "| `np.stack()`         | Joins along a new axis                        | Creating new dimensions      |\n",
+    "| `np.hstack()`        | Stacks arrays horizontally (axis=1)           | Combining columns            |\n",
+    "| `np.vstack()`        | Stacks arrays vertically (axis=0)             | Adding new rows              |\n",
+    "| `np.column_stack()`  | Turns 1D arrays into 2D columns               | Building a dataset           |\n",
+    "| `np.row_stack()`     | Turns 1D arrays into 2D rows                  | Appending examples           |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5564b131",
+   "metadata": {},
+   "source": [
+    "## Assignment - Pandas\n",
+    "### WHY Combine Data in Pandas?\n",
+    "\n",
+    "Combining data is a core operation in pandas — used when:\n",
+    "- Adding more rows (observations)\n",
+    "- Adding more columns (features)\n",
+    "- Merging data from different sources (e.g., different files, tables, or APIs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34dd1841",
+   "metadata": {},
+   "source": [
+    "### Methods of Combining Data\n",
+    "\n",
+    "| Method               | What It Does                                  \n",
+    "|----------------------|-----------------------------------------------|\n",
+    "| `concat()`           | Stack DataFrames vertically or horizontally   |\n",
+    "| `append()`           | Add rows to a DataFrame (deprecated)          |\n",
+    "| `merge()`            | SQL-style joins based on key columns          |\n",
+    "| `join()`             | Combine columns by index or key               |\n",
+    "| `combine_first()`    | Fill in missing values from another DataFrame |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "32a111d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "Students = {\n",
+    "    \"Name\": [\"John\", \"Reagan\", \"Nathan\", \"Abdullahi\", \"Bethany\"],\n",
+    "    \"Score\": [85, 90, 78, 88, 92],\n",
+    "    \"Age\": [20, 21, 19, 22, 20],\n",
+    "    \"Location\": [\"Juja\", \"Utawala\", \"Uthiru\", \"Kilimani\", \"Membley\"]\n",
+    "}\n",
+    "\n",
+    "data = pd.DataFrame(Students)\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16beb02b",
+   "metadata": {},
+   "source": [
+    "### 1. `pd.concat()` – Concatenation (Stacking Rows or Columns)\n",
+    "**What is pd.concat()?**\n",
+    "\n",
+    "`pd.concat()` is a Pandas function that concatenates (combines) DataFrames or Series along a particular axis (rows or columns). It's one of Pandas' most versatile data combination tools, allowing you to:\n",
+    "- Stack DataFrames vertically (row-wise)\n",
+    "- Combine DataFrames horizontally (column-wise)\n",
+    "- Handle different indexes from the source DataFrames\n",
+    "- Specify how to handle overlapping columns (when combining horizontally)\n",
+    "\n",
+    "Key Characteristics:\n",
+    "- Axis Flexibility: Can combine along rows (axis=0) or columns (axis=1)\n",
+    "- Index Preservation: By default keeps original indexes from source DataFrames\n",
+    "- Set Operations: Can perform unions (default) or intersections of indexes\n",
+    "- Multi-indexing: Can create hierarchical indexes when combining"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "b023cd74",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Moses</td>\n",
+       "      <td>75</td>\n",
+       "      <td>23</td>\n",
+       "      <td>Ngara</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Ruth</td>\n",
+       "      <td>82</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Thika</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley\n",
+       "0      Moses     75   23     Ngara\n",
+       "1       Ruth     82   21     Thika"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Combine two DataFrames row-wise (new entries)\n",
+    "\n",
+    "data1 = pd.DataFrame({\n",
+    "    \"Name\": [\"Moses\", \"Ruth\"],\n",
+    "    \"Score\": [75, 82],\n",
+    "    \"Age\": [23, 21],\n",
+    "    \"Location\": [\"Ngara\", \"Thika\"]\n",
+    "})\n",
+    "\n",
+    "combined = pd.concat([data, data1])\n",
+    "combined"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84aa87c3",
+   "metadata": {},
+   "source": [
+    "**Why Indexes Repeat (0 and 1)**\n",
+    "- `pd.concat()` preserves the original indexes from each DataFrame by default\n",
+    "- Not specifying `ignore_index=True`, it keeps the source indexes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "d70650ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Moses</td>\n",
+       "      <td>75</td>\n",
+       "      <td>23</td>\n",
+       "      <td>Ngara</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Ruth</td>\n",
+       "      <td>82</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Thika</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley\n",
+       "5      Moses     75   23     Ngara\n",
+       "6       Ruth     82   21     Thika"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combined = pd.concat([data, data1], ignore_index=True)\n",
+    "combined"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f918ef4d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location Gender\n",
+       "0       John     85   20      Juja      M\n",
+       "1     Reagan     90   21   Utawala      M\n",
+       "2     Nathan     78   19    Uthiru      M\n",
+       "3  Abdullahi     88   22  Kilimani      M\n",
+       "4    Bethany     92   20   Membley      F"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Combine column-wise\n",
+    "\n",
+    "extra = pd.DataFrame({\n",
+    "    \"Gender\": [\"M\", \"M\", \"M\", \"M\", \"F\"]\n",
+    "})\n",
+    "\n",
+    "# Add columns to existing df\n",
+    "extended = pd.concat([data, extra], axis=1)\n",
+    "extended"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5b23f77",
+   "metadata": {},
+   "source": [
+    "Use this when you're adding more features/columns to existing rows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19c17d3e",
+   "metadata": {},
+   "source": [
+    "## 2. pd.merge() – Database-style Merge (Joins)\n",
+    "\n",
+    "`pd.merge()` is primary a function for database-style joining of DataFrames, similar to SQL JOIN operations. It combines datasets based on the values of common columns (keys), offering various types of joins similar to SQL.\n",
+    "\n",
+    "Key Features\n",
+    "- SQL-like Joins: Supports INNER, LEFT, RIGHT, OUTER, and CROSS joins\n",
+    "- Flexible Key Specification: Can join on single or multiple columns\n",
+    "- Index/Column Joins: Can join on indexes or columns\n",
+    "- Suffix Handling: Automatically handles duplicate column names\n",
+    "- Indicator Column: Can add a column showing merge source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b5fa1c0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "04e2b40e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Ryan</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Name Gender\n",
+       "0     John      M\n",
+       "1   Nathan      M\n",
+       "2  Bethany      F\n",
+       "3     Ryan      M"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "join"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bd0567b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location Gender\n",
+       "0       John     85   20      Juja      M\n",
+       "1     Reagan     90   21   Utawala    NaN\n",
+       "2     Nathan     78   19    Uthiru      M\n",
+       "3  Abdullahi     88   22  Kilimani    NaN\n",
+       "4    Bethany     92   20   Membley      F"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Merge based on \"Name\"\n",
+    "join = pd.DataFrame({\n",
+    "    \"Name\": [\"John\", \"Nathan\", \"Bethany\", \"Ryan\"],\n",
+    "    \"Gender\": [\"M\", \"M\", \"F\", \"M\"]\n",
+    "})\n",
+    "\n",
+    "merged = pd.merge(data, join, on=\"Name\", how=\"left\")\n",
+    "merged"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47dcf690",
+   "metadata": {},
+   "source": [
+    "1. Successful Matches (Got Gender values):\n",
+    " - John (row 0) → Found in join → Gender = \"M\"\n",
+    " - Nathan (row 2) → Found in join → Gender = \"M\"\n",
+    " - Bethany (row 4) → Found in join → Gender = \"F\"\n",
+    "\n",
+    "2. Unmatched Records (Got NaN):\n",
+    " - Reagan → Not in join → Gender = NaN\n",
+    " - Abdullahi → Not in join → Gender = NaN\n",
+    "\n",
+    "3. Left Join Behavior:\n",
+    " - All original rows from `data` are preserved\n",
+    " - Only matching rows from `join` contribute gender values\n",
+    " - Non-matching names get `NaN` in the Gender column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "9acf3ec6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Name  Score  Age Location Gender\n",
+       "0     John     85   20     Juja      M\n",
+       "1   Nathan     78   19   Uthiru      M\n",
+       "2  Bethany     92   20  Membley      F"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(data, join, on=\"Name\", how=\"inner\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44443ee6",
+   "metadata": {},
+   "source": [
+    "Key Characteristics of Inner Join:\n",
+    "  - Exclusive Matching: Only returns rows with matching keys in both tables\n",
+    "  - No Missing Values: Never produces NaN in the result (unlike left/right/outer joins)\n",
+    "  - Smaller Output: Typically produces fewer rows than the original tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "995fa975",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78.0</td>\n",
+       "      <td>19.0</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92.0</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Ryan</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Name  Score   Age Location Gender\n",
+       "0     John   85.0  20.0     Juja      M\n",
+       "1   Nathan   78.0  19.0   Uthiru      M\n",
+       "2  Bethany   92.0  20.0  Membley      F\n",
+       "3     Ryan    NaN   NaN      NaN      M"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.merge(data, join, on=\"Name\", how=\"right\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3909eb63",
+   "metadata": {},
+   "source": [
+    "Explanation:\n",
+    "- Keeps all rows from the right DataFrame (join)\n",
+    "- Adds matching data from the left DataFrame (data)\n",
+    "- For \"Ryan\" (exists in join but not in data), all left DataFrame columns become NaN\n",
+    "- Names existing only in left DataFrame (Reagan, Abdullahi) are dropped\n",
+    "- Shows how right joins can reveal \"orphaned\" records in the right table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "bacfdaea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location\n",
+       "0       John     85   20      Juja\n",
+       "1     Reagan     90   21   Utawala\n",
+       "2     Nathan     78   19    Uthiru\n",
+       "3  Abdullahi     88   22  Kilimani\n",
+       "4    Bethany     92   20   Membley"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "f6f9d68f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score_original</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "      <th>Score_gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "      <td>85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "      <td>90</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "      <td>78</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Name  Score_original  Age Location Gender  Score_gender\n",
+       "0     John              85   20     Juja      M            85\n",
+       "1   Nathan              78   19   Uthiru      M            90\n",
+       "2  Bethany              92   20  Membley      F            78"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "suffix = pd.DataFrame({\n",
+    "    \"Name\": [\"John\", \"Nathan\", \"Bethany\", \"Ryan\"],\n",
+    "    \"Gender\": [\"M\", \"M\", \"F\", \"M\"],\n",
+    "    \"Score\": [85, 90, 78, 92]\n",
+    "})\n",
+    "\n",
+    "pd.merge(data, suffix, on=\"Name\", suffixes=('_original', '_gender'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b561ea5c",
+   "metadata": {},
+   "source": [
+    "1. Value Matching:\n",
+    "- For \"John\":\n",
+    "    - Score_original: 85 (from data)\n",
+    "    - Score_gender: 85 (from suffix)\n",
+    "\n",
+    "- For \"Nathan\":\n",
+    "    - Score_original: 78 (from data)\n",
+    "    - Score_gender: 90 (from suffix)\n",
+    "\n",
+    "- For \"Bethany\":\n",
+    "    - Score_original: 92 (from data)\n",
+    "    - Score_gender: 78 (from suffix)\n",
+    "\n",
+    "This type of merge is particularly valuable when:\n",
+    " - You need to compare values of the same metric from different sources\n",
+    " - You want to track changes in values over time\n",
+    " - You're combining datasets that measure the same attributes differently\n",
+    " - You need to identify discrepancies between data sources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15fa2f53",
+   "metadata": {},
+   "source": [
+    "Use this when you have extra data linked by a common key.\n",
+    "\n",
+    "Types of Join:\n",
+    "- how=\"inner\" → only matching rows\n",
+    "- how=\"left\" → all rows from left, matching from right\n",
+    "- how=\"right\" → all rows from right\n",
+    "- how=\"outer\" → all rows from both (fills in NaN where no match)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07afc3cb",
+   "metadata": {},
+   "source": [
+    "## 3. df.append() – (Deprecated) Add Rows\n",
+    "This method is deprecated in newer versions of pandas, so it's better to use `pd.concat()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7d257548",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'pandas' has no attribute 'append'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mAttributeError\u001b[39m                            Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 8\u001b[39m\n\u001b[32m      1\u001b[39m new_student = pd.DataFrame([{\n\u001b[32m      2\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mName\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mNaomi\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      3\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mScore\u001b[39m\u001b[33m\"\u001b[39m: \u001b[32m79\u001b[39m,\n\u001b[32m      4\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mAge\u001b[39m\u001b[33m\"\u001b[39m: \u001b[32m20\u001b[39m,\n\u001b[32m      5\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mLocation\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mNgong\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      6\u001b[39m }])\n\u001b[32m----> \u001b[39m\u001b[32m8\u001b[39m Students = \u001b[43mpd\u001b[49m\u001b[43m.\u001b[49m\u001b[43mappend\u001b[49m([data, new_student], ignore_index=\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[32m      9\u001b[39m Students\n",
+      "\u001b[31mAttributeError\u001b[39m: module 'pandas' has no attribute 'append'"
+     ]
+    }
+   ],
+   "source": [
+    "new_student = pd.DataFrame([{\n",
+    "    \"Name\": \"Naomi\",\n",
+    "    \"Score\": 79,\n",
+    "    \"Age\": 20,\n",
+    "    \"Location\": \"Ngong\"\n",
+    "}])\n",
+    "\n",
+    "Students = pd.append([data, new_student], ignore_index=True)\n",
+    "Students"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07acc8e",
+   "metadata": {},
+   "source": [
+    "## 4. df.join() – Add Columns by Index\n",
+    "`df.join()` is a Pandas method that combines DataFrames based on their indexes rather than column values. It's essentially a specialized version of pd.merge() optimized for index-based operations, with different default behaviors.\n",
+    "\n",
+    "Key Characteristics\n",
+    "- Index-Based Alignment: Joins DataFrames using their indexes (row labels)\n",
+    "- Column Concatenation: Horizontally combines columns from multiple DataFrames\n",
+    "- SQL-Like Joins: Supports left (default), right, inner, and outer join operations\n",
+    "- Convenience Method: Simplified syntax compared to merge() for index-based operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "17ff82a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Score</th>\n",
+       "      <th>Age</th>\n",
+       "      <th>Location</th>\n",
+       "      <th>Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>85</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Juja</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Reagan</td>\n",
+       "      <td>90</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Utawala</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Nathan</td>\n",
+       "      <td>78</td>\n",
+       "      <td>19</td>\n",
+       "      <td>Uthiru</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Abdullahi</td>\n",
+       "      <td>88</td>\n",
+       "      <td>22</td>\n",
+       "      <td>Kilimani</td>\n",
+       "      <td>M</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bethany</td>\n",
+       "      <td>92</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Membley</td>\n",
+       "      <td>F</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Name  Score  Age  Location Gender\n",
+       "0       John     85   20      Juja      M\n",
+       "1     Reagan     90   21   Utawala      M\n",
+       "2     Nathan     78   19    Uthiru      M\n",
+       "3  Abdullahi     88   22  Kilimani      M\n",
+       "4    Bethany     92   20   Membley      F"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "extra_info = pd.DataFrame({\n",
+    "    \"Gender\": [\"M\", \"M\", \"M\", \"M\", \"F\"]\n",
+    "}, index=[0, 1, 2, 3, 4])\n",
+    "\n",
+    "joined = data.join(extra_info)\n",
+    "joined\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cba2915",
+   "metadata": {},
+   "source": [
+    "Use this when rows are aligned by index, not keys."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b78d7aa0",
+   "metadata": {},
+   "source": [
+    "### Combining Data in Pandas – Official Documentation\n",
+    "\n",
+    "### Reference Links\n",
+    "\n",
+    "- [`concat()` docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.concat.html) – Add rows or columns.\n",
+    "- [`merge()` docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html) – Combine DataFrames using a key (like SQL JOIN).\n",
+    "- [`join()` docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.join.html) – Add columns by index.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Summary: When to Use What?\n",
+    "\n",
+    "| **Method** | **Use When...**                                           | **Aligns By**     |\n",
+    "|------------|-----------------------------------------------------------|-------------------|\n",
+    "| [`concat()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.concat.html) | Adding rows or columns to a DataFrame               | Axis (row/col)     |\n",
+    "| [`merge()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html)  | Merging datasets based on a key (like SQL JOIN)    | Key/Column         |\n",
+    "| [`join()`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.join.html)   | Adding columns when indexes align exactly           | Index              |\n",
+    "| `append()` *(Deprecated)* | Use for adding one DataFrame to another            | Axis=0 (rows)      |\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9e4f819",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
 This notebook demonstrates how to combine datasets using Pandas. The notebook  covers:
 - pd.concat():
  - Row-wise concatenation (stacking DataFrames vertically)
  - Column-wise concatenation (side-by-side merging)- pd.merge():
  - Merging DataFrames using different join types: inner, outer, left, and right
  - Merging on single or multiple keys- .join() method:
  - Join one DataFrame to another based on the index