### PR TITLE
Add folder for Machine Learning One Class Cohort 25W Notes

### DIFF
--- a/25w-notes/README.md
+++ b/25w-notes/README.md
@@ -1,0 +1,5 @@
+# Notes on Machine Learning One Class Cohort 25W 🎥
+
+| Date | Title |Submitted By | Link |
+|------|-------|---------|------|
+|2025-11-27|Naive Bayes|[@mwanyumba7](https://github.com/mwanyumba7)|[Link](https://app.zinduaschool.com/courses/machine-learning/lesson/naives-bayes-classification/)|


### PR DESCRIPTION
This pull request adds a new documentation file to track notes for the Machine Learning One Class Cohort 25W. The file introduces a table format for organizing lesson notes, including the date, title, submitter, and resource link.

Documentation additions:

* Created a new `25w-notes/README.md` file to record class notes for Cohort 25W, starting with an entry for the "Naive Bayes" lesson on 2025-11-27.